### PR TITLE
Update JGit dependency from 1.3.0 to 3.1.0 and refactor public API

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -102,7 +102,7 @@
 		<dependency>
 			<groupId>org.eclipse.jgit</groupId>
 			<artifactId>org.eclipse.jgit</artifactId>
-			<version>1.3.0.201202151440-r</version>
+			<version>3.1.0.201310021548-r</version>
 		</dependency>
 		<dependency>
 			<groupId>com.google.guava</groupId>

--- a/src/main/java/nl/minicom/gitolite/manager/exceptions/GitException.java
+++ b/src/main/java/nl/minicom/gitolite/manager/exceptions/GitException.java
@@ -1,0 +1,11 @@
+package nl.minicom.gitolite.manager.exceptions;
+
+public class GitException extends Exception {
+
+	private static final long serialVersionUID = -2225116453526869196L;
+	
+	public GitException(Throwable cause) {
+		super(cause);
+	}
+
+}

--- a/src/main/java/nl/minicom/gitolite/manager/git/GitManager.java
+++ b/src/main/java/nl/minicom/gitolite/manager/git/GitManager.java
@@ -3,6 +3,7 @@ package nl.minicom.gitolite.manager.git;
 import java.io.File;
 import java.io.IOException;
 
+import nl.minicom.gitolite.manager.exceptions.GitException;
 import nl.minicom.gitolite.manager.exceptions.ServiceUnavailable;
 
 /**
@@ -30,8 +31,10 @@ public interface GitManager {
 	 * 
 	 * @throws IOException If no matching file could be found, or the file could
 	 *            not be removed.
+	 *            
+	 * @throws GitException If an exception occurred while using the Git API.
 	 */
-	void remove(String filePattern) throws IOException;
+	void remove(String filePattern) throws IOException, GitException;
 
 	/**
 	 * This method clones a git repository from the specified URI, to the current
@@ -39,47 +42,48 @@ public interface GitManager {
 	 * 
 	 * @param uri The URI to clone the git repository from. This cannot be NULL.
 	 * 
-	 * @throws IOException If the clone operation failed, or if the working
-	 *            directory is not ready for a new git repository.
-	 *            
 	 * @throws ServiceUnavailable If the git server is unreachable or otherwise unavailable.
+	 * 
+	 * @throws GitException If an exception occurred while using the Git API.
 	 */
-	void clone(String uri) throws IOException, ServiceUnavailable;
+	void clone(String uri) throws ServiceUnavailable, GitException;
 
 	/**
 	 * This method initializes a new git repository in the working directory.
 	 * 
-	 * @throws IOException If no new git repository could be initialized.
+	 * @throws GitException If an exception occurred while using the Git API.
 	 */
-	void init() throws IOException;
+	void init() throws GitException;
 
 	/**
 	 * This method pulls new commits from the remote git repository.
 	 * 
 	 * @return True if new commits were found and pulled, false otherwise.
 	 * 
-	 * @throws IOException If the pull operation failed.
-	 * 
 	 * @throws ServiceUnavailable If the git server is unreachable or otherwise unavailable.
+	 * 
+	 * @throws GitException If an exception occurred while using the Git API.
 	 */
-	boolean pull() throws IOException, ServiceUnavailable;
+	boolean pull() throws ServiceUnavailable, GitException;
 
 	/**
 	 * Commits all changes to the working directory to the local git repository.
 	 * 
 	 * @throws IOException If the add or commit operations failed.
+	 * 
+	 * @throws GitException If an exception occurred while using the Git API.
 	 */
-	void commitChanges() throws IOException;
+	void commitChanges() throws IOException, GitException;
 
 	/**
 	 * This method pushes the locally committed changes to the remote git
 	 * repository.
 	 * 
-	 * @throws IOException If the push operation failed.
-	 * 
 	 * @throws ServiceUnavailable If the git server is unreachable or otherwise unavailable.
+	 * 
+	 * @throws GitException If an exception occurred while using the Git API.
 	 */
-	void push() throws IOException, ServiceUnavailable;
+	void push() throws ServiceUnavailable, GitException;
 
 	/**
 	 * @return The working directory of this {@link JGitManager} object.

--- a/src/test/java/nl/minicom/gitolite/manager/git/JGitManagerTest.java
+++ b/src/test/java/nl/minicom/gitolite/manager/git/JGitManagerTest.java
@@ -4,6 +4,7 @@ import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 
+import nl.minicom.gitolite.manager.exceptions.GitException;
 import nl.minicom.gitolite.manager.exceptions.ServiceUnavailable;
 
 import org.junit.Assert;
@@ -32,7 +33,7 @@ public class JGitManagerTest {
 	}
 
 	@Test
-	public void testOpenExistingWorkingDirectory() throws IOException {
+	public void testOpenExistingWorkingDirectory() throws IOException, GitException {
 		File dir = Files.createTempDir();
 		new JGitManager(dir, null).init();
 
@@ -40,7 +41,7 @@ public class JGitManagerTest {
 	}
 
 	@Test
-	public void testRemoveFileFromWorkingDirectory() throws IOException {
+	public void testRemoveFileFromWorkingDirectory() throws IOException, GitException {
 		File dir = Files.createTempDir();
 		JGitManager jGitManager = new JGitManager(dir, null);
 		jGitManager.init();
@@ -58,7 +59,7 @@ public class JGitManagerTest {
 	}
 
 	@Test
-	public void testCloningExistingRepo() throws IOException, ServiceUnavailable {
+	public void testCloningExistingRepo() throws ServiceUnavailable, GitException {
 		File location = Files.createTempDir();
 		new JGitManager(location, null).init();
 
@@ -67,14 +68,14 @@ public class JGitManagerTest {
 	}
 
 	@Test
-	public void testInitializingNewRepo() throws IOException {
+	public void testInitializingNewRepo() throws GitException {
 		File dir = Files.createTempDir();
 		new JGitManager(dir, null).init();
 		Assert.assertTrue(new File(dir, ".git").exists());
 	}
 
 	@Test
-	public void testPullingFromExistingRepo() throws IOException, ServiceUnavailable {
+	public void testPullingFromExistingRepo() throws IOException, ServiceUnavailable, GitException {
 		File location = Files.createTempDir();
 		GitManager orig = new JGitManager(location, null);
 		orig.init();
@@ -93,7 +94,7 @@ public class JGitManagerTest {
 	}
 
 	@Test
-	public void testCommittingChangesToRepo() throws IOException {
+	public void testCommittingChangesToRepo() throws IOException, GitException {
 		File location = Files.createTempDir();
 		GitManager orig = new JGitManager(location, null);
 		orig.init();
@@ -101,7 +102,7 @@ public class JGitManagerTest {
 	}
 
 	@Test
-	public void testPushingToRemoteRepo() throws IOException, ServiceUnavailable {
+	public void testPushingToRemoteRepo() throws IOException, ServiceUnavailable, GitException {
 		File cloneDirectory = Files.createTempDir();
 		File workingDirectory = Files.createTempDir();
 		File location = Files.createTempDir();


### PR DESCRIPTION
This PR updates the JGit dependency to 3.1.0 and cleans up the use of Exceptions in the public API.
