### PR TITLE
Changed preconditions for User, Group and SSH key names

### DIFF
--- a/src/main/java/nl/minicom/gitolite/manager/models/Group.java
+++ b/src/main/java/nl/minicom/gitolite/manager/models/Group.java
@@ -58,7 +58,7 @@ public final class Group implements Identifiable {
 	Group(String name, Recorder recorder) {
 		Preconditions.checkNotNull(name);
 		Preconditions.checkArgument(!name.isEmpty());
-		Preconditions.checkArgument(name.startsWith("@"));
+		Preconditions.checkArgument(name.matches("^\\@\\w[\\w._\\@+-]+$"), "\"" + name + "\" is not a valid group name");
 		Preconditions.checkNotNull(recorder);
 		
 		this.name = name;

--- a/src/main/java/nl/minicom/gitolite/manager/models/User.java
+++ b/src/main/java/nl/minicom/gitolite/manager/models/User.java
@@ -53,6 +53,7 @@ public final class User implements Identifiable {
 	User(String name, Recorder recorder) {
 		Preconditions.checkNotNull(name);
 		Preconditions.checkArgument(!name.isEmpty());
+		Preconditions.checkArgument(name.matches("^\\w[\\w._\\@+-]+$"), "\"" + name + "\" is not a valid user name");
 		Preconditions.checkNotNull(recorder);
 		
 		this.name = name;

--- a/src/test/java/nl/minicom/gitolite/manager/integration/TestUsernameCharacters.java
+++ b/src/test/java/nl/minicom/gitolite/manager/integration/TestUsernameCharacters.java
@@ -1,0 +1,231 @@
+package nl.minicom.gitolite.manager.integration;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
+
+import org.eclipse.jgit.api.Git;
+import org.eclipse.jgit.lib.ProgressMonitor;
+import org.eclipse.jgit.transport.JschConfigSessionFactory;
+import org.eclipse.jgit.transport.OpenSshConfig;
+import org.eclipse.jgit.transport.OpenSshConfig.Host;
+import org.eclipse.jgit.transport.SshSessionFactory;
+import org.eclipse.jgit.util.FS;
+import org.junit.After;
+import org.junit.Assume;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Strings;
+import com.google.common.io.Files;
+import com.jcraft.jsch.JSch;
+import com.jcraft.jsch.JSchException;
+import com.jcraft.jsch.KeyPair;
+import com.jcraft.jsch.Session;
+
+import nl.minicom.gitolite.manager.models.Config;
+import nl.minicom.gitolite.manager.models.ConfigManager;
+import nl.minicom.gitolite.manager.models.Group;
+import nl.minicom.gitolite.manager.models.Permission;
+import nl.minicom.gitolite.manager.models.Repository;
+import nl.minicom.gitolite.manager.models.User;
+
+@RunWith(Parameterized.class)
+public class TestUsernameCharacters {
+
+	private static final Logger log = LoggerFactory.getLogger(TestUsernameCharacters.class);
+	
+	private static final String CLONE_URL = "https://github.com/devhub-tud/Java-Gitolite-Manager.git";
+	
+    @Parameters(name = "{index}: testUsername({0})")
+    public static Collection<Object[]> data() {
+		return Arrays.asList(new Object[][] { { "Username" }, { "User-name" },
+			{ "Username-" }, { "User+name" }, { "Username+" },
+			{ "User.name" }, { "Username." }, { "User_name" },
+			{ "Username_" } });
+    }
+	
+	private ConfigManager manager;
+
+	private String adminUsername;
+	
+	private String baseUrl;
+
+	private File stagingDirectory;
+
+	@Before
+	public void setUp() throws Exception {
+		resetSshSessionFactory();
+		
+		String gitUri = System.getProperty("gitUri");
+		baseUrl = gitUri.substring(0, gitUri.indexOf("gitolite-admin"));
+		
+		adminUsername = System.getProperty("gitAdmin", "git");
+		boolean runTests = !Strings.isNullOrEmpty(gitUri);
+		Assume.assumeTrue(runTests);
+		
+		manager = ConfigManager.create(gitUri);
+		stagingDirectory = Files.createTempDir();
+		clearEverything();
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		resetSshSessionFactory();
+		clearEverything();
+		stagingDirectory.delete();
+	}
+	
+	private final String username;
+	
+	public TestUsernameCharacters(final String username) {
+		this.username = username;
+	}
+
+	private void clearEverything() throws Exception {
+		Config config = manager.get();
+
+		for (User user : config.getUsers()) {
+			if (!adminUsername.equals(user.getName())) {
+				config.removeUser(user);
+			}
+		}
+		
+		for (Group group : config.getGroups()) {
+			config.removeGroup(group);
+		}
+		
+		for (Repository repo : config.getRepositories()) {
+			if (!"gitolite-admin".equals(repo.getName())) {
+				config.removeRepository(repo);
+			}
+		}
+		
+		manager.apply(config);
+	}
+
+	@Test
+	public void testUsername() throws Exception {
+		
+		final KeyPair keyPair = KeyPair.genKeyPair( new JSch(), KeyPair.RSA);
+		
+		Config config = manager.get();
+		User user = config.createUser(username);
+		String keyContents = getPublicKeyContents(keyPair);
+		user.setKey("Key1", keyContents);
+		Repository repository = config.createRepository("bliep");
+		repository.setPermission(user, Permission.READ_WRITE);
+		manager.apply(config);
+		
+		
+		String repoUrl = baseUrl + repository.getName();
+		
+		Git repo = Git.cloneRepository()
+			.setBare(false)
+			.setDirectory(stagingDirectory)
+			.setURI(CLONE_URL)
+			.setProgressMonitor(new LogProgressMonitor("cloning from " + CLONE_URL))
+			.call();
+		
+		setKeyForSsh(keyPair);
+		
+		repo.push()
+			.setRemote(repoUrl)
+			.setPushAll()
+			.setPushTags()
+			.setProgressMonitor(new LogProgressMonitor("pushing to " + repoUrl))
+			.call();
+	}
+	
+	private void resetSshSessionFactory() {
+		SshSessionFactory.setInstance(new DefaultSshSessionFactory());	
+	}
+	
+	private void setKeyForSsh(KeyPair keyPair) {
+		SshSessionFactory.setInstance(new PublicKeySessionFactory(keyPair));
+	}
+	
+	private static String getPublicKeyContents(final KeyPair keypair) {
+		try(ByteArrayOutputStream out = new ByteArrayOutputStream()) {
+			keypair.writePublicKey(out, "");
+			return out.toString();
+		}
+		catch (IOException e) {
+			throw new RuntimeException(e);
+		}
+	}
+	
+	static class DefaultSshSessionFactory extends JschConfigSessionFactory {
+		
+		@Override
+		protected void configure(Host hc, Session session) {
+		}
+		
+	}
+	
+	static class PublicKeySessionFactory extends DefaultSshSessionFactory {
+		
+		private final KeyPair keyPair;
+		
+		public PublicKeySessionFactory(final KeyPair keyPair) {
+			this.keyPair = keyPair;
+		}
+
+		@Override
+		protected JSch getJSch(final OpenSshConfig.Host hc, FS fs) throws JSchException {
+			JSch jSch = super.getJSch(hc, fs);
+			jSch.removeAllIdentity();
+			try (ByteArrayOutputStream bas = new ByteArrayOutputStream();
+				ByteArrayOutputStream bis = new ByteArrayOutputStream()) {
+				keyPair.writePrivateKey(bas);
+				keyPair.writePublicKey(bis, "");
+				jSch.addIdentity("another", bas.toByteArray(), bis.toByteArray(), (byte[]) null);
+			}
+			catch (Exception e){
+				log.warn(e.getMessage(), e);
+				throw new RuntimeException(e);
+			}
+			return jSch;
+		}
+		
+	}
+	
+	static class LogProgressMonitor implements ProgressMonitor {
+
+		private final String task;
+		
+		public LogProgressMonitor(final String task) {
+			this.task = task;
+		}
+		
+		@Override
+		public void start(int totalTasks) {
+			log.info("Starting {} with {} tasks", task, totalTasks);
+		}
+
+		@Override
+		public void beginTask(String title, int totalWork) {}
+
+		@Override
+		public void update(int completed) {}
+
+		@Override
+		public void endTask() {
+			log.info("Finished {}", task);
+		}
+
+		@Override
+		public boolean isCancelled() {
+			return false;
+		}
+		
+	}
+	
+}


### PR DESCRIPTION
User and group names are checked against the regexes defined in Gitolite:
    https://github.com/sitaramc/gitolite/blob/dc8b590a0562ab7dc4bdab9511fe6c31cb422ae8/src/lib/Gitolite/Rc.pm#L53

This is related to https://github.com/devhub-tud/git-server/issues/34
